### PR TITLE
FEAT-RankRoom을-생성-기능-구현#6 v0.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.goorm.wordsketch'
-version = '0.0.2'
+version = '0.0.3'
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/org/goorm/wordsketch/rank/exception_handling/ExceptionResponseHandler.java
+++ b/src/main/java/org/goorm/wordsketch/rank/exception_handling/ExceptionResponseHandler.java
@@ -1,6 +1,7 @@
 package org.goorm.wordsketch.rank.exception_handling;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
@@ -14,6 +15,14 @@ public class ExceptionResponseHandler {
     return ResponseEntity
         .status(responseStatusException.getStatusCode())
         .body(responseStatusException.getBody().getDetail());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<String> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException httpMessageNotReadableException) {
+    return ResponseEntity
+        .status(400)
+        .body("요청에 필요한 값들을 찾을 수 없습니다.");
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyController.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyController.java
@@ -1,10 +1,13 @@
 package org.goorm.wordsketch.rank.ranklobby;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.goorm.wordsketch.rank.ranklobby.dto.RankRoomInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +30,17 @@ public class RankLobbyController {
         .toList();
 
     return ResponseEntity.ok(rankRoomInfos);
+  }
+
+  @PostMapping("/rankroom")
+  public ResponseEntity<String> registRankRoom(@RequestBody String roomName) {
+
+    RankRoom createdRankRoom = rankLobbyService.registRankRoom(RankRoom.builder()
+        .roomUUID(UUID.randomUUID().toString())
+        .roomName(roomName)
+        .headCount(1)
+        .build());
+
+    return ResponseEntity.ok(createdRankRoom.getRoomUUID());
   }
 }

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
@@ -31,4 +31,15 @@ public class RankLobbyService {
 
     return rankRoomRepository.findAll();
   }
+
+  /**
+   * 주어진 방 이름과 일치하는 RankRoom Entity를 반환하는 함수
+   * 
+   * @param roomName
+   * @return
+   */
+  public RankRoom getRankRoom(String roomName) {
+
+    return null;
+  }
 }

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
@@ -2,7 +2,9 @@ package org.goorm.wordsketch.rank.ranklobby;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +42,7 @@ public class RankLobbyService {
    */
   public RankRoom getRankRoom(String roomName) {
 
-    return null;
+    return rankRoomRepository.findByRoomName(roomName)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "방 제목과 일치하는 방이 존재하지 않습니다."));
   }
 }

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoom.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoom.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,9 @@ public class RankRoom {
   @Id
   private String roomUUID;
 
+  @Indexed
   private String roomName;
+
   private int headCount;
 
   @Builder.Default

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoomRepository.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoomRepository.java
@@ -1,6 +1,10 @@
 package org.goorm.wordsketch.rank.ranklobby;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.ListCrudRepository;
 
 public interface RankRoomRepository extends ListCrudRepository<RankRoom, String> {
+
+  Optional<RankRoom> findByRoomName(String roomName);
 }

--- a/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCheckApiTest.java
+++ b/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCheckApiTest.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 @DisplayName("경쟁 어휘 학습 로비 API 인수테스트")
-public class RankLobbyAPITest {
+public class RankRoomCheckApiTest {
 
   private final WebTestClient webTestClient;
 
@@ -95,9 +95,13 @@ public class RankLobbyAPITest {
       @DisplayName("에러코드 401을 메세지와 함께 반환한다.")
       void 에러코드_401을_메세지와_함께_반환한다() {
 
-        responseSpec
+        String returnedServerResponse = responseSpec
             .expectStatus().isUnauthorized()
-            .expectBody(String.class);
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertEquals("올바르지 않은 accessToken 입니다.", returnedServerResponse);
       }
     }
 
@@ -114,9 +118,13 @@ public class RankLobbyAPITest {
       @DisplayName("에러코드 400을 메세지와 함께 반환한다.")
       void 에러코드_400을_메세지와_함께_반환한다() {
 
-        responseSpec
+        String returnedServerResponse = responseSpec
             .expectStatus().isBadRequest()
-            .expectBody(String.class);
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertEquals("요청에 쿠키가 존재하지 않습니다.", returnedServerResponse);
       }
     }
   }

--- a/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCreateApiTest.java
+++ b/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCreateApiTest.java
@@ -39,8 +39,8 @@ public class RankRoomCreateApiTest {
     }
 
     @Nested
-    @DisplayName("When: 올바른 accessToken과 함께 지정한 방 이름으로 생성을 요청하면,")
-    class When_올바른_accessToken과_함께_지정한_방_이름으로_생성을_요청하면 {
+    @DisplayName("When: 올바른 accessToken과 함께 특정 방 이름 생성 요청하면,")
+    class When_올바른_accessToken과_함께_특정_방_이름_생성_요청하면 {
 
       private String accessToken = jwtService.createAccessTokenForTest("test@email.com");
       private String testRoomName = "테스트 방";
@@ -68,8 +68,8 @@ public class RankRoomCreateApiTest {
     }
 
     @Nested
-    @DisplayName("When: accessToken과 함께 지정한 방 이름없이 방 생성을 요청하면,")
-    class When_accessToken과_함께_지정한_방_이름없이_방_생성을_요청하면 {
+    @DisplayName("When: accessToken과 함께 방 이름없이 방 생성 요청하면,")
+    class When_accessToken과_함께_방_이름없이_방_생성_요청하면 {
 
       private String accessToken = jwtService.createAccessTokenForTest("test@email.com");
 
@@ -94,8 +94,8 @@ public class RankRoomCreateApiTest {
     }
 
     @Nested
-    @DisplayName("When: 올바르지 않은 accessToken과 함께 방 생성을 요청하면,")
-    class When_올바르지_않은_accessToken과_함께_방_생성을_요청하면 {
+    @DisplayName("When: 올바르지 않은 accessToken과 함께 방 생성 요청하면,")
+    class When_올바르지_않은_accessToken과_함께_방_생성_요청하면 {
 
       private String accessToken = "InvalidAccessToken";
 

--- a/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCreateApiTest.java
+++ b/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCreateApiTest.java
@@ -1,0 +1,145 @@
+package org.goorm.wordsketch.rank.acceptance.lobby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.goorm.wordsketch.rank.acceptance.global.AcceptanceTest;
+import org.goorm.wordsketch.rank.ranklobby.RankLobbyService;
+import org.goorm.wordsketch.rank.security.jwt.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
+
+import lombok.RequiredArgsConstructor;
+
+@AcceptanceTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@DisplayName("경쟁 어휘 학습 방 생성 API 인수테스트")
+public class RankRoomCreateApiTest {
+
+  private final WebTestClient webTestClient;
+  private final RankLobbyService rankLobbyService;
+  private final JwtService jwtService;
+
+  @Value("${jwt.access.cookie}")
+  private String accessCookie;
+
+  @Nested
+  @DisplayName("Given: 서버에 방이 하나도 없을 때,")
+  class Given_서버에_방이_하나도_없을_때 {
+
+    // AcceptanceTestExecutionListener에서 매 테스트 전후로 DB를 초기화
+    Given_서버에_방이_하나도_없을_때() {
+
+      assertEquals(0, rankLobbyService.getAllRankRooms().size());
+    }
+
+    @Nested
+    @DisplayName("When: 올바른 accessToken과 함께 지정한 방 이름으로 생성을 요청하면,")
+    class When_올바른_accessToken과_함께_지정한_방_이름으로_생성을_요청하면 {
+
+      private String accessToken = jwtService.createAccessTokenForTest("test@email.com");
+      private String testRoomName = "테스트 방";
+
+      ResponseSpec responseSpec = webTestClient
+          .post()
+          .uri("/rank/lobby/rankroom")
+          .cookie(accessCookie, accessToken)
+          .bodyValue(testRoomName)
+          .exchange();
+
+      @Test
+      @DisplayName("Then: 서버에 요청한 방이 생성된다.")
+      void Then_서버에_요청한_방이_생성된다() {
+
+        responseSpec
+            .expectStatus().isOk()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        // DB에도 생성되었는지 roomName을 기준으로 확인
+        assertEquals(testRoomName, rankLobbyService.getRankRoom(testRoomName).getRoomName());
+      }
+    }
+
+    @Nested
+    @DisplayName("When: accessToken과 함께 지정한 방 이름없이 방 생성을 요청하면,")
+    class When_accessToken과_함께_지정한_방_이름없이_방_생성을_요청하면 {
+
+      private String accessToken = jwtService.createAccessTokenForTest("test@email.com");
+
+      ResponseSpec responseSpec = webTestClient
+          .post()
+          .uri("/rank/lobby/rankroom")
+          .cookie(accessCookie, accessToken)
+          .exchange();
+
+      @Test
+      @DisplayName("에러코드 400을 메세지와 함께 반환한다.")
+      void 에러코드_400을_메세지와_함께_반환한다() {
+
+        String returnedServerResponse = responseSpec
+            .expectStatus().isBadRequest()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertEquals("요청에 필요한 값들을 찾을 수 없습니다.", returnedServerResponse);
+      }
+    }
+
+    @Nested
+    @DisplayName("When: 올바르지 않은 accessToken과 함께 방 생성을 요청하면,")
+    class When_올바르지_않은_accessToken과_함께_방_생성을_요청하면 {
+
+      private String accessToken = "InvalidAccessToken";
+
+      ResponseSpec responseSpec = webTestClient
+          .post()
+          .uri("/rank/lobby/rankroom")
+          .cookie(accessCookie, accessToken)
+          .exchange();
+
+      @Test
+      @DisplayName("에러코드 401을 메세지와 함께 반환한다.")
+      void 에러코드_401을_메세지와_함께_반환한다() {
+
+        String returnedServerResponse = responseSpec
+            .expectStatus().isUnauthorized()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertEquals("올바르지 않은 accessToken 입니다.", returnedServerResponse);
+      }
+    }
+
+    @Nested
+    @DisplayName("When: accessToken 없이 방 생성을 요청하면,")
+    class When_accessToken_없이_방_생성을_요청하면 {
+
+      ResponseSpec responseSpec = webTestClient
+          .post()
+          .uri("/rank/lobby/rankroom")
+          .exchange();
+
+      @Test
+      @DisplayName("에러코드 400을 메세지와 함께 반환한다.")
+      void 에러코드_400을_메세지와_함께_반환한다() {
+
+        String returnedServerResponse = responseSpec
+            .expectStatus().isBadRequest()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertEquals("요청에 쿠키가 존재하지 않습니다.", returnedServerResponse);
+      }
+    }
+  }
+}


### PR DESCRIPTION
> 게임방 생성 기능 구현

**관련 이슈**
resolves #6

- 조회와 마찬가지로 쿠키에 유효한 accessToken이 있어야지만 방 생성 가능하도록 구현
- 방 제목으로 RankRoom을 조회하는 서비스 구현
- 응답 메세지에 생성된 방의 UUID 반환

**테스트 결과**
<img width="331" alt="image" src="https://github.com/PANTS-GOORM/Rank/assets/77713508/5657f784-5f56-445c-aaea-8cc77b52f7bd">
