### PR TITLE
FEAT-RankRoom-입장-기능-구현#8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
   implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.boot:spring-boot-starter-websocket'
   implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
   runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'

--- a/src/main/java/org/goorm/wordsketch/rank/db/redis/RedisConfig.java
+++ b/src/main/java/org/goorm/wordsketch/rank/db/redis/RedisConfig.java
@@ -5,8 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -21,16 +23,26 @@ public class RedisConfig {
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
 
-    return new LettuceConnectionFactory(redisHost, redisPort);
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
   }
 
   @Primary
   @Bean
   public RedisTemplate<String, Object> redisTemplate() {
+
     RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     return redisTemplate;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory redisConnectionFactory) {
+
+    RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+    redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+    return redisMessageListenerContainer;
   }
 }

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyController.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyController.java
@@ -11,18 +11,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/rank/lobby")
+@RequestMapping("/lobby")
 @RequiredArgsConstructor
 public class RankLobbyController {
 
   private final RankLobbyService rankLobbyService;
 
   @GetMapping()
-  public ResponseEntity<List<RankRoomInfo>> getAllRankRoomInfos(HttpServletRequest request) {
+  public ResponseEntity<List<RankRoomInfo>> getAllRankRoomInfos() {
 
     List<RankRoomInfo> rankRoomInfos = rankLobbyService.getAllRankRooms()
         .stream()
@@ -38,7 +37,6 @@ public class RankLobbyController {
     RankRoom createdRankRoom = rankLobbyService.registRankRoom(RankRoom.builder()
         .roomUUID(UUID.randomUUID().toString())
         .roomName(roomName)
-        .headCount(1)
         .build());
 
     return ResponseEntity.ok(createdRankRoom.getRoomUUID());

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankLobbyService.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankLobbyService {
@@ -21,6 +23,7 @@ public class RankLobbyService {
    */
   public RankRoom registRankRoom(RankRoom rankRoom) {
 
+    log.info(rankRoom.toString());
     return rankRoomRepository.save(rankRoom);
   }
 

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoom.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoom.java
@@ -1,15 +1,17 @@
 package org.goorm.wordsketch.rank.ranklobby;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Arrays;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 @Builder
 @RedisHash
 public class RankRoom {
@@ -20,7 +22,14 @@ public class RankRoom {
   @Indexed
   private String roomName;
 
-  private int headCount;
+  @Builder.Default
+  private boolean inGame = false;
+
+  @Builder.Default
+  private List<String> players = Arrays.asList("");
+
+  @Builder.Default
+  private List<Boolean> playersStatus = Arrays.asList(true);
 
   @Builder.Default
   private LocalDateTime createdDate = LocalDateTime.now();

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoomRepository.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/RankRoomRepository.java
@@ -3,8 +3,12 @@ package org.goorm.wordsketch.rank.ranklobby;
 import java.util.Optional;
 
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.lang.NonNull;
 
 public interface RankRoomRepository extends ListCrudRepository<RankRoom, String> {
+
+  @NonNull
+  Optional<RankRoom> findById(@NonNull String roomUUID);
 
   Optional<RankRoom> findByRoomName(String roomName);
 }

--- a/src/main/java/org/goorm/wordsketch/rank/ranklobby/dto/RankRoomInfo.java
+++ b/src/main/java/org/goorm/wordsketch/rank/ranklobby/dto/RankRoomInfo.java
@@ -17,7 +17,7 @@ public class RankRoomInfo {
 
     this.roomUUID = rankRoom.getRoomUUID();
     this.roomName = rankRoom.getRoomName();
-    this.headCount = rankRoom.getHeadCount();
+    this.headCount = rankRoom.getPlayers().size() - 1;
   }
 
   @Override

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/GameProgressInfo.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/GameProgressInfo.java
@@ -1,0 +1,31 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@RedisHash
+public class GameProgressInfo {
+
+  @Id
+  private String roomUUID;
+
+  @Builder.Default
+  private int round = 0;
+
+  private int wholeRound;
+
+  private RankRoomStatus rankRoomStatus;
+
+  private String answer;
+  private String imageURL;
+
+  private List<String> players;
+  private int[] scores;
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/GuessInfoRepository.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/GuessInfoRepository.java
@@ -1,0 +1,12 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.lang.NonNull;
+
+public interface GuessInfoRepository extends CrudRepository<GameProgressInfo, String> {
+
+  @NonNull
+  Optional<GameProgressInfo> findById(@NonNull String roomUUID);
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankGameService.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankGameService.java
@@ -1,0 +1,102 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankGameService {
+
+  private final TaskScheduler taskScheduler;
+  private final RankRoomService rankRoomService;
+  private final SimpMessagingTemplate simpMessagingTemplate;
+  private Map<String, ScheduledFuture<?>> scheduledFutures = new ConcurrentHashMap<>();
+
+  @Async
+  public void startRankGame(String userUUID) {
+
+    String roomUUID = rankRoomService.startRankGame(userUUID);
+    scheduledFutures.put("GUESS-" + roomUUID, taskScheduler.schedule(() -> guessStep(roomUUID),
+        Instant.now().plusSeconds(5)));
+
+    simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.VIEW)
+        .payload("COUNT-DOWN")
+        .build());
+  }
+
+  @Async
+  public void guessStep(String roomUUID) {
+
+    String imageURL = rankRoomService.guessStep(roomUUID);
+    scheduledFutures.put("NO_SCORE-" + roomUUID, taskScheduler.schedule(() -> noScoreStep(roomUUID),
+        Instant.now().plusSeconds(30)));
+
+    simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.VIEW)
+        .payload("GUESS")
+        .imageURL(imageURL)
+        .build());
+  }
+
+  public void validateAnswer(String roomUUID, String userUUID, String payload) {
+
+    RankRoomMessage rankRoomMessage = rankRoomService.validateAnswer(roomUUID, userUUID, payload);
+    if (rankRoomMessage == null)
+      return;
+
+    // 최초 정답자라면, 실패 로직 예약을 취소
+    ScheduledFuture<?> scheduledFuture = scheduledFutures.get("NO_SCORE-" + roomUUID);
+    if (scheduledFuture != null) {
+      scheduledFuture.cancel(false);
+      // scheduledFutures.remove("SCORE-" + roomUUID);
+
+      scheduledFutures.put("CHECK-" + roomUUID, taskScheduler.schedule(() -> checkRound(roomUUID),
+          Instant.now().plusSeconds(5)));
+      // 성공 및 득점 메세지 전파
+      simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, rankRoomMessage);
+    }
+  }
+
+  @Async
+  public void noScoreStep(String roomUUID) {
+
+    rankRoomService.skipRound(roomUUID);
+    scheduledFutures.put("CHECK-" + roomUUID, taskScheduler.schedule(() -> checkRound(roomUUID),
+        Instant.now().plusSeconds(5)));
+
+    // 아무도 정답을 맞추지 못했으므로, 실패 메세지 전파
+    simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.VIEW)
+        .payload("NO_SCORE")
+        .build());
+  }
+
+  @Async
+  public void checkRound(String roomUUID) {
+
+    RankRoomMessage rankRoomMessage = rankRoomService.isLastRound(roomUUID);
+    if (rankRoomMessage != null) {
+
+      simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, rankRoomMessage);
+      return;
+    }
+
+    scheduledFutures.put("GUESS-" + roomUUID, taskScheduler.schedule(() -> guessStep(roomUUID),
+        Instant.now().plusSeconds(5)));
+
+    simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.VIEW)
+        .payload("COUNT-DOWN")
+        .build());
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomController.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomController.java
@@ -1,0 +1,70 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rankroom")
+public class RankRoomController {
+
+  private final RankRoomService rankRoomService;
+  private final RankGameService rankGameService;
+  private final SimpMessagingTemplate simpMessagingTemplate;
+
+  @SubscribeMapping("/rankroom/{roomUUID}")
+  @SendTo("/sub/rankroom/{roomUUID}")
+  public RankRoomMessage initialReply(@DestinationVariable String roomUUID, Principal principal) {
+
+    return rankRoomService.getInitialReplyData(roomUUID, principal.getName());
+  }
+
+  @MessageMapping("/rankroom/{roomUUID}")
+  @SendTo("/sub/rankroom/{roomUUID}")
+  public RankRoomMessage sendChat(@DestinationVariable String roomUUID, String payload, Principal principal)
+      throws Exception {
+
+    rankGameService.validateAnswer(roomUUID, principal.getName(), payload);
+
+    return RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.CHAT)
+        .payload(principal.getName() + ":" + payload)
+        .build();
+  }
+
+  @PutMapping("/player-status")
+  public ResponseEntity<String> switchPlayerStatus(Principal principal) {
+
+    String roomUUID = rankRoomService.getUserLocation(principal.getName()).getRoomUUID();
+    List<Boolean> playersStatus = rankRoomService.setPlayerStatus(principal.getName(), roomUUID);
+
+    // 게임방에 참가자 준비 상태 전파
+    simpMessagingTemplate.convertAndSend("/sub/rankroom/" + roomUUID, RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.STATUS)
+        .playersStatus(playersStatus)
+        .build());
+
+    return ResponseEntity.ok("성공적으로 상태를 변경했습니다.");
+  }
+
+  @PostMapping("rankgame")
+  public ResponseEntity<Void> startRankGame(Principal principal) {
+
+    rankGameService.startRankGame(principal.getName());
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomMessage.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomMessage.java
@@ -1,0 +1,19 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankRoomMessage {
+
+  private RankRoomMessageType rankRoomMessageType;
+  private List<String> players;
+  private List<Boolean> playersStatus;
+  private int scorePlayerIdx;
+  private int[] playersScore;
+  private String payload;
+  private String imageURL;
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomMessageType.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomMessageType.java
@@ -1,0 +1,6 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+public enum RankRoomMessageType {
+
+  ENTER, CHAT, VIEW, STATUS
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomService.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomService.java
@@ -1,0 +1,279 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.goorm.wordsketch.rank.ranklobby.RankRoom;
+import org.goorm.wordsketch.rank.ranklobby.RankRoomRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankRoomService {
+
+  private final RankRoomRepository rankRoomRepository;
+  private final GuessInfoRepository gameProgressInfoRepository;
+  private final UserLocationRepository userLocationRepository;
+
+  private final String GUESS_PREFIX = "GUESS";
+
+  /**
+   * roomUUID에 해당하는 RankRoom을 반환하는 함수
+   * 대응하는 RankRoom이 존재하지 않으면 404 에러 반환
+   * 
+   * @param roomUUID
+   * @return
+   */
+  public RankRoom getRankRoomByRoomUUID(String roomUUID) {
+
+    return rankRoomRepository.findById(roomUUID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 경쟁방이 존재하지 않습니다."));
+  }
+
+  /**
+   * roomUUID에 해당하는 GuessInfo를 반환하는 함수
+   * 대응하는 GuessInfo이 존재하지 않으면 404 에러 반환
+   * 
+   * @param roomUUID
+   * @return
+   */
+  public GameProgressInfo getGuessInfoByRoomUUID(String roomUUID) {
+
+    return gameProgressInfoRepository.findById(GUESS_PREFIX + roomUUID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당하는 경쟁방이 존재하지 않습니다."));
+  }
+
+  public UserLocation getUserLocation(String userUUID) {
+
+    return userLocationRepository.findById(userUUID)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 유저의 위치를 확인할 수 없습니다."));
+  }
+
+  /**
+   * roomUUID에 해당하는 RankRoom의 인원 수를 1 증가시키고, 참여자 정보에 userUUID을 추가하는 함수
+   * 
+   * @param roomUUID
+   * @param userUUID
+   */
+  public void rankRoomEntrance(String roomUUID, String userUUID) {
+
+    // 유저가 참가 중인 방 정보 받아오기
+    Optional<UserLocation> prevUserLocation = userLocationRepository.findById(userUUID);
+
+    // 유저가 방에 존재한다면 기존 RankRoom에 퇴장 처리
+    if (prevUserLocation.isPresent())
+      rankRoomExit(userUUID);
+
+    // roomUUID에 해당하는 RankRoom 조회
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+
+    // RankRoom players 리스트에 추가
+    rankRoom.getPlayers().add(userUUID);
+    rankRoom.getPlayersStatus().add(false);
+
+    // 유저가 참가 중인 방 정보 업데이트
+    UserLocation userLocation = UserLocation.builder()
+        .userUUID(userUUID)
+        .roomUUID(roomUUID)
+        .build();
+
+    userLocationRepository.save(userLocation);
+
+    // 변경한 RankRoom 정보를 DB에 영속화
+    rankRoomRepository.save(rankRoom);
+  }
+
+  /**
+   * roomUUID에 해당하는 RankRoom의 인원 수를 1 감소시키고, 참여자 정보에 userUUID을 제거하는 함수
+   * 
+   * @param roomUUID
+   * @param userUUID
+   */
+  public void rankRoomExit(String userUUID) {
+
+    // 유저가 참가 중인 방 정보 받아오기
+    Optional<UserLocation> userLocation = userLocationRepository.findById(userUUID);
+
+    // 유저가 방에 존재하지 않는다면 종료
+    if (!userLocation.isPresent())
+      return;
+
+    UserLocation userLocationInfo = userLocation.get();
+
+    // 유저가 방에 존재한다면 roomUUID에 해당하는 RankRoom에 퇴장정보 업데이트
+    String roomUUID = userLocationInfo.getRoomUUID();
+
+    // roomUUID에 해당하는 RankRoom이 존재하지 않으면 404 에러 반환
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+
+    // RankRoom players와 status 리스트에서 제거
+    int playerIdx = rankRoom.getPlayers().indexOf(userUUID);
+    rankRoom.getPlayers().remove(userUUID);
+    rankRoom.getPlayersStatus().remove(playerIdx);
+
+    // 변경한 RankRoom 정보를 DB에 영속화
+    rankRoomRepository.save(rankRoom);
+
+    // 유저가 참가 중인 방 정보 삭제
+    userLocationRepository.delete(userLocationInfo);
+  }
+
+  public RankRoomMessage getInitialReplyData(String roomUUID, String userUUID) {
+
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+    List<String> players = rankRoom.getPlayers();
+    List<Boolean> playersStatus = rankRoom.getPlayersStatus();
+
+    return RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.ENTER)
+        .players(players)
+        .playersStatus(playersStatus)
+        .payload(userUUID + "님이 입장하셨습니다.")
+        .build();
+  }
+
+  /**
+   * 유저가 속한 게임방에 접근하여 유저의 준비 상태를 변경하는 함수
+   * 
+   * @param userUUID
+   * @param ready
+   * @return 게임방에 속한 모든 참가자의 준비 상태 배열
+   */
+  public List<Boolean> setPlayerStatus(String userUUID, String roomUUID) {
+
+    // 유저가 속해있는 게임방에 준비 상태 업데이트
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+    int idxOfPlayer = rankRoom.getPlayers().indexOf(userUUID);
+    rankRoom.getPlayersStatus().set(idxOfPlayer, !rankRoom.getPlayersStatus().get(idxOfPlayer));
+    rankRoomRepository.save(rankRoom);
+
+    // 게임방에 속한 모든 참가자의 준비 상태 배열 반환
+    return rankRoom.getPlayersStatus();
+  }
+
+  /**
+   * RankRoom의 준비상태를 검증 후, 카운트다운 단계로 진입
+   * 
+   * @param roomUUID
+   */
+  public String startRankGame(String userUUID) {
+
+    String roomUUID = getUserLocation(userUUID).getRoomUUID();
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+    List<Boolean> playersStatus = rankRoom.getPlayersStatus();
+    for (boolean playerStatus : playersStatus) {
+
+      if (playerStatus == false)
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "준비되지 않은 참가자가 있습니다.");
+    }
+
+    rankRoom.setInGame(true);
+    rankRoomRepository.save(rankRoom);
+
+    // TODO 라운드 설정 받아오기
+    int wholeRound = 5;
+
+    // 게임 진행 정보 생성
+    gameProgressInfoRepository.save(GameProgressInfo.builder()
+        .roomUUID(GUESS_PREFIX + roomUUID)
+        .wholeRound(wholeRound)
+        .rankRoomStatus(RankRoomStatus.COUNTDOWN)
+        .players(rankRoom.getPlayers())
+        .scores(new int[rankRoom.getPlayers().size()])
+        .build());
+
+    return roomUUID;
+  }
+
+  /**
+   * 출제할 문제를 선택해서 게임 진행 상황을 업데이트하는 함수
+   * 
+   * @param roomUUID
+   * @return 어휘와 관련된 이미지가 업로드된 URL
+   */
+  public String guessStep(String roomUUID) {
+
+    // TODO 문제 선택 로직으로 수정
+    String answer = "필름";
+    String imageURL = "https://jogakbo-album-image-storage.s3.ap-northeast-2.amazonaws.com/05421507-ac7f-4e85-9b8a-69a1b55ce5c1/7d7e0e08-3292-4407-9620-706fa9f8eaa0.png";
+
+    GameProgressInfo gameProgressInfo = getGuessInfoByRoomUUID(roomUUID);
+    gameProgressInfo.setAnswer(answer);
+    gameProgressInfo.setImageURL(imageURL);
+    gameProgressInfo.setRankRoomStatus(RankRoomStatus.GUESS);
+    gameProgressInfoRepository.save(gameProgressInfo);
+
+    return imageURL;
+  }
+
+  public RankRoomMessage validateAnswer(String roomUUID, String userUUID, String paylaod) {
+
+    if (!getRankRoomByRoomUUID(roomUUID).isInGame())
+      return null;
+
+    GameProgressInfo gameProgressInfo = getGuessInfoByRoomUUID(roomUUID);
+    if (gameProgressInfo.getRankRoomStatus() != RankRoomStatus.GUESS || !gameProgressInfo.getAnswer().equals(paylaod))
+      return null;
+
+    gameProgressInfo.setRound(gameProgressInfo.getRound() + 1);
+    gameProgressInfo.setRankRoomStatus(RankRoomStatus.SCORE);
+    int playerIdx = gameProgressInfo.getPlayers().indexOf(userUUID);
+    gameProgressInfo.getScores()[playerIdx]++;
+    gameProgressInfoRepository.save(gameProgressInfo);
+
+    return RankRoomMessage.builder()
+        .rankRoomMessageType(RankRoomMessageType.VIEW)
+        .payload("SCORE")
+        .players(gameProgressInfo.getPlayers())
+        .scorePlayerIdx(playerIdx)
+        .playersScore(gameProgressInfo.getScores())
+        .build();
+  }
+
+  public void skipRound(String roomUUID) {
+
+    GameProgressInfo gameProgressInfo = getGuessInfoByRoomUUID(roomUUID);
+    gameProgressInfo.setRound(gameProgressInfo.getRound() + 1);
+    gameProgressInfoRepository.save(gameProgressInfo);
+  }
+
+  public RankRoomMessage isLastRound(String roomUUID) {
+
+    GameProgressInfo gameProgressInfo = getGuessInfoByRoomUUID(roomUUID);
+
+    if (gameProgressInfo.getRound() == gameProgressInfo.getWholeRound()) {
+
+      endGame(roomUUID);
+
+      return RankRoomMessage.builder()
+          .rankRoomMessageType(RankRoomMessageType.VIEW)
+          .payload("RESULT")
+          .players(gameProgressInfo.getPlayers())
+          .playersScore(gameProgressInfo.getScores())
+          .build();
+    }
+
+    return null;
+  }
+
+  public void endGame(String roomUUID) {
+
+    RankRoom rankRoom = getRankRoomByRoomUUID(roomUUID);
+
+    // 플레이어 대기 상태 초기화
+    rankRoom.setPlayersStatus(
+        rankRoom.getPlayersStatus().stream().map((status) -> true).toList());
+
+    // 게임방 상태 변경
+    rankRoom.setInGame(false);
+    rankRoomRepository.save(rankRoom);
+
+    // 게임 진행 정보 삭제
+    GameProgressInfo gameProgressInfo = getGuessInfoByRoomUUID(roomUUID);
+    gameProgressInfoRepository.delete(gameProgressInfo);
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomStatus.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomStatus.java
@@ -1,0 +1,6 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+public enum RankRoomStatus {
+
+  COUNTDOWN, GUESS, SCORE, RESULT
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomViewType.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/RankRoomViewType.java
@@ -1,0 +1,6 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+public enum RankRoomViewType {
+
+  GUESS, SCORE, RESULT
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/UserLocation.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/UserLocation.java
@@ -1,0 +1,18 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@RedisHash
+public class UserLocation {
+
+  @Id
+  private String userUUID;
+
+  private String roomUUID;
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/UserLocationRepository.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/UserLocationRepository.java
@@ -1,0 +1,6 @@
+package org.goorm.wordsketch.rank.rankroom;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserLocationRepository extends CrudRepository<UserLocation, String> {
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/FilterChannelInterceptor.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/FilterChannelInterceptor.java
@@ -1,0 +1,105 @@
+package org.goorm.wordsketch.rank.rankroom.stomp;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import org.goorm.wordsketch.rank.rankroom.RankRoomService;
+import org.goorm.wordsketch.rank.security.PasswordUtil;
+import org.goorm.wordsketch.rank.security.jwt.JwtService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@Component
+@RequiredArgsConstructor
+public class FilterChannelInterceptor implements ChannelInterceptor {
+
+  private final JwtService jwtService;
+  private final RankRoomService rankRoomService;
+  private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+  @Value("${jwt.access.cookie}")
+  private String accessCookie;
+
+  @SuppressWarnings("null")
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+
+    StompHeaderAccessor stompHeaderAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+    Assert.notNull(stompHeaderAccessor, "StompHeaderAccessor를 찾을 수 없습니다.");
+    if (stompHeaderAccessor.getCommand() == StompCommand.CONNECT) {
+
+      // 담겨있는 유저 userUUID가 유효한 지 검증 후 추출
+      String accessToken = String.valueOf(stompHeaderAccessor.getNativeHeader(accessCookie).get(0));
+      Optional<String> userEmail = jwtService.validateAccessToken(accessToken);
+
+      // 확인된 userUUID 를 기반으로 세션 유저 설정
+      userEmail.ifPresent((userUUID) -> {
+
+        String password = PasswordUtil.generateRandomPassword();
+
+        UserDetails userDetailsUser = User.builder()
+            .username(userUUID)
+            .password(password)
+            .roles("USER")
+            .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+            authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        stompHeaderAccessor.setUser(authentication);
+      });
+
+    } else if (stompHeaderAccessor.getCommand() == StompCommand.SUBSCRIBE) {
+
+      // stompHeaderAccessor 에서 roomUUID, 유저 userUUID 추출
+      String roomUUID = stompHeaderAccessor.getDestination().split("/")[3];
+      String userUUID = stompHeaderAccessor.getUser().getName();
+
+      // null 값이 담겨있다면 잘못된 요청임을 알림
+      if (roomUUID == null || userUUID == null)
+        throw new MessageDeliveryException("요청 헤더의 값들이 올바르지 않습니다.");
+
+      // roomUUID에 해당하는 RankRoom에 입장정보 업데이트
+      rankRoomService.rankRoomEntrance(roomUUID, userUUID);
+
+    } else if (stompHeaderAccessor.getCommand() == StompCommand.DISCONNECT) {
+
+      // stompHeaderAccessor 에서 userUUID 추출
+      Optional<Principal> user = Optional.ofNullable(stompHeaderAccessor.getUser());
+      user.ifPresent((userDetails) -> {
+
+        String userUUID = userDetails.getName();
+
+        // 클라이언트와 StompSubProtocolMessageHandler, 둘 다 요청을 보낼 수 있으므로
+        // 유저 위치를 재확인하는 로직을 포함하는 rankRoomExit 함수 호출
+        rankRoomService.rankRoomExit(userUUID);
+      });
+    }
+    return message;
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/StompErrorHandler.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/StompErrorHandler.java
@@ -1,0 +1,42 @@
+package org.goorm.wordsketch.rank.rankroom.stomp;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+
+  @SuppressWarnings("null")
+  @Override
+  public Message<byte[]> handleClientMessageProcessingError(
+      Message<byte[]> message,
+      Throwable throwable) {
+
+    if ("올바르지 않은 accessToken 입니다.".equals(throwable.getMessage())) {
+
+      log.info("에러 발생");
+      return errorMessage("유저 인증에 실패하여 연결에 실패했습니다.");
+    }
+
+    return super.handleClientMessageProcessingError(message, throwable);
+  }
+
+  private Message<byte[]> errorMessage(String errorMessage) {
+
+    StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.create(StompCommand.ERROR);
+    stompHeaderAccessor.setLeaveMutable(true);
+
+    return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8),
+        stompHeaderAccessor.getMessageHeaders());
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/WebSocketConfig.java
+++ b/src/main/java/org/goorm/wordsketch/rank/rankroom/stomp/WebSocketConfig.java
@@ -1,0 +1,45 @@
+package org.goorm.wordsketch.rank.rankroom.stomp;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  private final StompErrorHandler stompErrorHandler;
+  private final FilterChannelInterceptor filterChannelInterceptor;
+
+  @SuppressWarnings("null")
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+
+    config.enableSimpleBroker("/sub");
+    config.setApplicationDestinationPrefixes("/pub", "/sub");
+  }
+
+  @SuppressWarnings("null")
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+    // 로컬 개발 환경과 배포 환경을 위한 CORS 설정
+    registry.addEndpoint("/rank-ws").setAllowedOrigins("http://localhost:3000", "https://wordsketch.site/");
+
+    // 커스텀 에러 핸들러 설정
+    registry.setErrorHandler(stompErrorHandler);
+  }
+
+  @SuppressWarnings("null")
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+
+    registration.interceptors(filterChannelInterceptor);
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/scheduler/SchedulerConfig.java
+++ b/src/main/java/org/goorm/wordsketch/rank/scheduler/SchedulerConfig.java
@@ -1,0 +1,22 @@
+package org.goorm.wordsketch.rank.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+@EnableAsync
+public class SchedulerConfig {
+
+  @Bean
+  public TaskScheduler taskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setThreadNamePrefix("TaskScheduler-");
+    scheduler.setPoolSize(50); // 원하는 쓰레드 풀 사이즈 설정
+    return scheduler;
+  }
+}

--- a/src/main/java/org/goorm/wordsketch/rank/security/SecurityConfig.java
+++ b/src/main/java/org/goorm/wordsketch/rank/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         // 모든 URL에 대해 인증 필수 설정
         .authorizeHttpRequests(requests -> requests
-            // .requestMatchers("/error").permitAll()
+            .requestMatchers("/rank-ws").permitAll()
             .anyRequest().authenticated())
         // Cors 설정
         .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))

--- a/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCheckApiTest.java
+++ b/src/test/java/org/goorm/wordsketch/rank/acceptance/lobby/RankRoomCheckApiTest.java
@@ -45,7 +45,6 @@ public class RankRoomCheckApiTest {
     RankRoom rankRoom = RankRoom.builder()
         .roomUUID(UUID.randomUUID().toString())
         .roomName("테스트 RankRoom")
-        .headCount(1)
         .build();
 
     RankRoom savedRankRoom = rankLobbyService.registRankRoom(rankRoom);

--- a/src/test/java/org/goorm/wordsketch/rank/acceptance/rankroom/RankRoomEntranceApiTest.java
+++ b/src/test/java/org/goorm/wordsketch/rank/acceptance/rankroom/RankRoomEntranceApiTest.java
@@ -1,0 +1,245 @@
+package org.goorm.wordsketch.rank.acceptance.rankroom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Type;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.goorm.wordsketch.rank.acceptance.global.AcceptanceTest;
+import org.goorm.wordsketch.rank.ranklobby.RankLobbyService;
+import org.goorm.wordsketch.rank.ranklobby.RankRoom;
+import org.goorm.wordsketch.rank.rankroom.RankRoomService;
+import org.goorm.wordsketch.rank.security.jwt.JwtService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AcceptanceTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@DisplayName("경쟁 학습 방 입장 API 인수테스트")
+public class RankRoomEntranceApiTest {
+
+  private final JwtService jwtService;
+  private final RankRoomService rankRoomService;
+  private final RankLobbyService rankLobbyService;
+
+  @LocalServerPort
+  private int portNum;
+
+  @Nested
+  @DisplayName("Given: 서버에 학습방이 있을 때,")
+  class Given_서버에_학습방이_있을_때 {
+
+    RankRoom createdRankRoom = rankLobbyService.registRankRoom(RankRoom.builder()
+        .roomUUID(UUID.randomUUID().toString())
+        .roomName("접속 테스트 방")
+        .build());
+
+    @Nested
+    @DisplayName("When: 올바른 accessToken과 함께 roomUUID로 참여를 요청하면,")
+    class 올바른_accessToken과_함께_roomUUID로_참여를_요청하면 {
+
+      private String stompUrl;
+      private String testUserEmail;
+      private String testAccessToken;
+      private StompSession stompSession;
+
+      올바른_accessToken과_함께_roomUUID로_참여를_요청하면() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // Stomp 테스트를 위한 클라언트 객체 생성
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new StringMessageConverter());
+
+        // 테스트 유저용 testAccessToken 발행
+        testUserEmail = "test@email.com";
+        testAccessToken = jwtService.createAccessTokenForTest(testUserEmail);
+        log.info(testAccessToken);
+
+        // Stomp Filter 인증을 위해 헤더 설정
+        StompHeaders stompHeaders = new StompHeaders();
+        stompHeaders.add("AccessToken", testAccessToken);
+
+        // connect()가 완료되고 stompSession를 반환할 때까지 대기
+        // 2초가 지나면 TimeOutException 발생
+        stompUrl = "ws://localhost:" + portNum + "/rank-ws";
+        stompSession = stompClient
+            .connectAsync(stompUrl, new WebSocketHttpHeaders(), stompHeaders, new StompSessionHandlerAdapter() {
+            }).get(2, TimeUnit.SECONDS);
+      }
+
+      @Test
+      @DisplayName("Then: 학습방 채팅에 참여할 수 있다.")
+      void Then_학습방_채팅에_참여할_수_있다() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // 테스트 쓰레드가 먼저 꺼지는 걸 방지하기 위해, CompletableFuture를 사용
+        CompletableFuture<String> subscribeFuture = new CompletableFuture<>();
+
+        // Stomp 메세지 구독 등록
+        String testRoomUUID = createdRankRoom.getRoomUUID();
+        String subUrl = "/sub/rankroom/" + testRoomUUID;
+        stompSession.subscribe(subUrl, new StompFrameHandler() {
+
+          // 메세지 타입 지정
+          @SuppressWarnings("null")
+          @Override
+          public Type getPayloadType(StompHeaders headers) {
+            return String.class;
+          }
+
+          // 메세지 파싱
+          @SuppressWarnings("null")
+          @Override
+          public void handleFrame(StompHeaders headers, Object payload) {
+
+            subscribeFuture.complete(String.valueOf(payload));
+          }
+        });
+
+        // 테스트 채팅 메세지 발행
+        String testPubMessage = "메세지 발송 확인 테스트 메세지 입니다.";
+        String pubUrl = "/pub/rankroom/" + testRoomUUID;
+        stompSession.send(pubUrl, testPubMessage);
+
+        // 값이 들어올때 까지 최대 3초간 기다림
+        String subscribedMessage = subscribeFuture.get(3, TimeUnit.SECONDS);
+
+        // 메세지가 일치하는지 확인
+        assertEquals(testPubMessage, subscribedMessage);
+
+        // 현재 유저 위치가 구독한 roomUUID 인지 확인
+        assertEquals(testRoomUUID, rankRoomService.getUserLocation(testUserEmail).getRoomUUID());
+
+        // 세션 종료 후, 해당 유저의 위치 확인
+        stompSession.disconnect();
+        Thread.sleep(100);
+
+        assertThrows(ResponseStatusException.class,
+            () -> rankRoomService.getUserLocation(testUserEmail));
+      }
+    }
+
+    @Nested
+    @DisplayName("When: 올바르지 않은 accessToken과 함께 방 참여를 요청하면,")
+    class When_올바르지_않은_accessToken과_함께_방_참여를_요청하면 {
+
+      private WebSocketStompClient stompClient;
+      private String stompUrl;
+      private StompHeaders stompHeaders;
+
+      When_올바르지_않은_accessToken과_함께_방_참여를_요청하면() {
+
+        // Stomp 테스트를 위한 클라언트 객체 생성
+        stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new StringMessageConverter());
+
+        // 테스트 유저용 testAccessToken 발급
+        String testAccessToken = "InvalidAccessToken";
+
+        // Stomp Filter 인증을 위해 헤더 설정
+        stompHeaders = new StompHeaders();
+        stompHeaders.add("AccessToken", testAccessToken);
+
+        // connect()가 완료되고 stompSession를 반환할 때까지 대기
+        // 2초가 지나면 TimeOutException 발생
+        stompUrl = "ws://localhost:" + portNum + "/rank-ws";
+      }
+
+      @Test
+      @DisplayName("에러코드 401을 메세지와 함께 반환한다.")
+      void 에러코드_401을_메세지와_함께_반환한다() throws InterruptedException, ExecutionException, TimeoutException {
+
+        stompClient
+            .connectAsync(stompUrl, new WebSocketHttpHeaders(), stompHeaders, new StompSessionHandlerAdapter() {
+
+              @SuppressWarnings("null")
+              @Override
+              public void handleTransportError(StompSession stompSession, Throwable throwable) {
+
+                log.info("에러 확인");
+                log.info("Error -- " + throwable);
+              }
+
+            }).get(2, TimeUnit.SECONDS);
+      }
+    }
+
+    @Nested
+    @DisplayName("When: accessToken 없이 방 참여를 요청하면,")
+    class When_accessToken_없이_방_참여를_요청하면 {
+
+      private WebSocketStompClient stompClient;
+      private String stompUrl;
+      private StompHeaders stompHeaders;
+
+      When_accessToken_없이_방_참여를_요청하면() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // Stomp 테스트를 위한 클라언트 객체 생성
+        stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new StringMessageConverter());
+
+        // 테스트 유저용 testAccessToken 발급
+        String testAccessToken = "InvalidAccessToken";
+
+        // Stomp Filter 인증을 위해 헤더 설정
+        stompHeaders = new StompHeaders();
+        stompHeaders.add("AccessToken", testAccessToken);
+
+        // connect()가 완료되고 stompSession를 반환할 때까지 대기
+        // 2초가 지나면 TimeOutException 발생
+        stompUrl = "ws://localhost:" + portNum + "/rank-ws";
+      }
+
+      @Test
+      @DisplayName("에러코드 400을 메세지와 함께 반환한다.")
+      void 에러코드_400을_메세지와_함께_반환한다() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // assertThrows(ResponseStatusException.class, () -> stompClient
+        // .connectAsync(stompUrl, new WebSocketHttpHeaders(), stompHeaders, new
+        // StompSessionHandlerAdapter() {
+        // }).get(2, TimeUnit.SECONDS));
+        CompletableFuture<StompSession> session = stompClient
+            .connectAsync(stompUrl, new WebSocketHttpHeaders(), stompHeaders, new StompSessionHandlerAdapter() {
+
+              @SuppressWarnings("null")
+              @Override
+              public void handleException(StompSession session, @Nullable StompCommand command,
+                  StompHeaders headers, byte[] payload, Throwable exception) {
+
+                log.info("HEREEE");
+              }
+
+              @SuppressWarnings("null")
+              @Override
+              public void handleTransportError(StompSession stompSession, Throwable throwable) {
+
+                log.info("Err:");
+                log.info(throwable.getCause().getLocalizedMessage());
+              }
+            });
+      }
+    }
+  }
+}


### PR DESCRIPTION
# 경쟁학습 관련 API 구현 작업

- 경쟁학습 로비 API
  - 방 목록 조회 API (GET /lobby)
  - 방 생성 API (POST /lobby/rankroom)

- 경쟁학습 게임방 API
  - 채팅용 웹소켓 API (WSS rank-ws)
  - 채팅 구독 API (SUBSCRIBE /sub/rankroom/{roomUUID})
  - 채팅 전송 API (SEND /pub/rankroom/{roomUUID})
  - 준비 상태 변경 API (PUT /rankroom/player-status)
  - 게임 시작 API (POST /rankroom/rankgame)

**테스트 커버리지 90%**

**관련 이슈**
resolves #8